### PR TITLE
fix(jql): Get missing issues

### DIFF
--- a/main.go
+++ b/main.go
@@ -261,7 +261,7 @@ func syncIssues(jiraClient *jira.Client, mongoClient *mongo.Client, config *Conf
 	updatedDocuments := make(map[string]bool)
 
 	// JQL query to get main issues
-	jql := "project = OCPBUGS AND component = Hypershift AND \"Target Version\" = 4.19.0 AND \"Target Backport Versions\" is not EMPTY"
+	jql := `project = OCPBUGS AND component in (Hypershift, "HyperShift / Agent", "HyperShift / ARO", "HyperShift / OCP Virtualization", "HyperShift / OpenStack", "HyperShift / ROSA") AND "Target Backport Versions" is not EMPTY AND issueLinkType not in ("depends on")`
 
 	// Search issues in Jira
 	searchOptions := &jira.SearchOptions{


### PR DESCRIPTION
The previous jql query was missing:
* Subcomponents: Agent, ARO, OCPV, OpenStack, ROSA
* Was missing issues that were opened targeting older (and in the future newer) releases that might still be missing backports.

Of course, the resulting jql is not perfect either, as there can be bugs that are marked as dependent to other bugs that they are not backports of. That case is not too frequent, but I believe we could try to address it in the future.